### PR TITLE
 Replace YieldProcessor with sleep for 10 milliseconds due to busy-wait loop

### DIFF
--- a/source/coresystem/cs_param.cpp
+++ b/source/coresystem/cs_param.cpp
@@ -3,6 +3,9 @@
 #include <detail/singleton.hpp>
 #include <detail/windows.inl>
 
+#include <thread>
+#include <chrono>
+
 using namespace from;
 
 LIBER_SINGLETON_INSTANCE(CS::SoloParamRepository);
@@ -25,11 +28,11 @@ bool CS::SoloParamRepository::wait_for_params(int timeout) {
         while (!are_params_ready(num_loaded)) {
             if (GetTickCount64() > wait)
                 return false;
-            YieldProcessor();
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
     else {
-        while (!are_params_ready(num_loaded)) YieldProcessor();
+        while (!are_params_ready(num_loaded)) std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     return true;
 }

--- a/source/dantelion2/system.cpp
+++ b/source/dantelion2/system.cpp
@@ -3,6 +3,9 @@
 
 #include <detail/windows.inl>
 
+#include <thread>
+#include <chrono>
+
 using namespace from;
 
 bool DLSY::wait_for_system(int timeout) noexcept {
@@ -13,11 +16,11 @@ bool DLSY::wait_for_system(int timeout) noexcept {
         while (*counter == 0) {
             if (GetTickCount64() > wait)
                 return false;
-            YieldProcessor();
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
     }
     else {
-        while (*counter == 0) YieldProcessor();
+        while (*counter == 0) std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     return true;
 }


### PR DESCRIPTION
Calling `from::DLSY::wait_for_system` or/ and `from::CS::SoloParamRepository::wait_for_params` causes noticeable slowdowns, and can cause a total hang if called too many times (on my machine, around 14 calls to those functions are enough to completely stop the loading process). I replaced `YieldProcessor` with `std::this_thread::sleep_for(std::chrono::milliseconds(10))`, and this has fixed the problem.